### PR TITLE
Update redis_exporter from 1.61.0 to 1.62.0

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -235,7 +235,7 @@ packages:
     context:
       static:
         <<: *default_static_context
-        version: 1.61.0
+        version: 1.62.0
         license: MIT
         summary: Prometheus exporter for Redis server metrics.
         description: Prometheus Exporter for Redis Metrics. Supports Redis 2.x, 3.x, 4.x, 5.x and 6.x


### PR DESCRIPTION
https://github.com/oliver006/redis_exporter/releases/tag/v1.62.0
- PR https://github.com/oliver006/redis_exporter/pull/917 - fix stream entry id metric for Redis 6 (thx @gitsang )
- PR https://github.com/oliver006/redis_exporter/pull/921 - Bump alpine to use latest 3.20 image (thx @neiljain )
