### PR TITLE
Update redis_exporter from 1.61.0 to 1.63.0

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -235,7 +235,7 @@ packages:
     context:
       static:
         <<: *default_static_context
-        version: 1.61.0
+        version: 1.63.0
         license: MIT
         summary: Prometheus exporter for Redis server metrics.
         description: Prometheus Exporter for Redis Metrics. Supports Redis 2.x, 3.x, 4.x, 5.x and 6.x


### PR DESCRIPTION
https://github.com/oliver006/redis_exporter/releases/tag/v1.63.0
- PR https://github.com/oliver006/redis_exporter/pull/924 - Add add label master_replid to metricinstance_info (thx @wilkice)
- PR https://github.com/oliver006/redis_exporter/pull/933 - Export client-output-buffer-limit (thx @jdheyburn)
- Updated dependencies: Golang 1.23, prometheus/client_golang 1.20.2,