### PR TITLE
Update pushgateway from 1.9.0 to 1.10.0

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -359,7 +359,7 @@ packages:
       <<: *default_context
       static:
         <<: *default_static_context
-        version: 1.9.0
+        version: 1.10.0
         license: ASL 2.0
         URL: https://github.com/prometheus/pushgateway
         summary: Prometheus push acceptor for ephemeral and batch jobs.


### PR DESCRIPTION
https://github.com/prometheus/pushgateway/releases/tag/v1.10.0
- [FEATURE] API: Support classic float histograms. https://github.com/prometheus/pushgateway/pull/668
- [BUGFIX] Update dependencies to pull in possibly relevant bugfixes.

