### PR TITLE
Update alertmanager from 0.27.0 to 0.28.0

### DIFF
--- a/templating.yaml
+++ b/templating.yaml
@@ -49,7 +49,7 @@ packages:
       <<: *default_context
       static:
         <<: *default_static_context
-        version: 0.27.0
+        version: 0.28.0
         license: ASL 2.0
         URL: https://github.com/prometheus/alertmanager
         service_opts:


### PR DESCRIPTION
https://github.com/prometheus/alertmanager/releases/tag/v0.28.0

- [CHANGE] Templating errors in the SNS integration now return an error. https://github.com/prometheus/alertmanager/pull/3531 https://github.com/prometheus/alertmanager/pull/3879
- [CHANGE] Adopt log/slog, drop go-kit/log https://github.com/prometheus/alertmanager/pull/4089
- [FEATURE] Add a new Microsoft Teams integration based on Flows https://github.com/prometheus/alertmanager/pull/4024
- [FEATURE] Add a new Rocket.Chat integration https://github.com/prometheus/alertmanager/pull/3600
- [FEATURE] Add a new Jira integration https://github.com/prometheus/alertmanager/pull/3590 https://github.com/prometheus/alertmanager/pull/3931
- [FEATURE] Add support for GOMEMLIMIT, enable it via the feature flag --enable-feature=auto-gomemlimit. https://github.com/prometheus/alertmanager/pull/3895
- [FEATURE] Add support for GOMAXPROCS, enable it via the feature flag --enable-feature=auto-gomaxprocs. https://github.com/prometheus/alertmanager/pull/3837
- [FEATURE] Add support for limits of silences including the maximum number of active and pending silences, and the maximum size per silence (in bytes). You can use the flags --silences.max-silences and --silences.max-silence-size-bytes to set them accordingly https://github.com/prometheus/alertmanager/pull/3852 https://github.com/prometheus/alertmanager/pull/3862 https://github.com/prometheus/alertmanager/pull/3866 https://github.com/prometheus/alertmanager/pull/3885 https://github.com/prometheus/alertmanager/pull/3886 https://github.com/prometheus/alertmanager/pull/3877
- [FEATURE] Muted alerts now show whether they are suppressed or not in both the /api/v2/alerts endpoint and the Alertmanager UI. https://github.com/prometheus/alertmanager/pull/3793 https://github.com/prometheus/alertmanager/pull/3797 https://github.com/prometheus/alertmanager/pull/3792
- [ENHANCEMENT] Add support for content, username and avatar_url in the Discord integration. content and username also support templating. https://github.com/prometheus/alertmanager/pull/4007
- [ENHANCEMENT] Only invalidate the silences cache if a new silence is created or an existing silence replaced - should improve latency on both GET api/v2/alerts and POST api/v2/alerts API endpoint. https://github.com/prometheus/alertmanager/pull/3961
- [ENHANCEMENT] Add image source label to Dockerfile. To get changelogs shown when using Renovate https://github.com/prometheus/alertmanager/pull/4062
- [ENHANCEMENT] Build using go 1.23 https://github.com/prometheus/alertmanager/pull/4071
- [ENHANCEMENT] Support setting a global SMTP TLS configuration. https://github.com/prometheus/alertmanager/pull/3732
- [ENHANCEMENT] The setting room_id in the WebEx integration can now be templated to allow for dynamic room IDs. https://github.com/prometheus/alertmanager/pull/3801
- [ENHANCEMENT] Enable setting message_thread_id for the Telegram integration. https://github.com/prometheus/alertmanager/pull/3638
- [ENHANCEMENT] Support the since and humanizeDuration functions to templates. This means users can now format time to more human-readable text. https://github.com/prometheus/alertmanager/pull/3863
- [ENHANCEMENT] Support the date and tz functions to templates. This means users can now format time in a specified format and also change the timezone to their specific locale. https://github.com/prometheus/alertmanager/pull/3812
- [ENHANCEMENT] Latency metrics now support native histograms. https://github.com/prometheus/alertmanager/pull/3737
- [ENHANCEMENT] Add full width to adaptive card for msteamsv2 https://github.com/prometheus/alertmanager/pull/4135
- [ENHANCEMENT] Add timeout option for webhook notifier. https://github.com/prometheus/alertmanager/pull/4137
- [ENHANCEMENT] Update config to allow showing secret values when marshaled https://github.com/prometheus/alertmanager/pull/4158
- [ENHANCEMENT] Enable templating for Jira project and issue_type https://github.com/prometheus/alertmanager/pull/4159
- [BUGFIX] Fix the SMTP integration not correctly closing an SMTP submission, which may lead to unsuccessful dispatches being marked as successful. https://github.com/prometheus/alertmanager/pull/4006
- [BUGFIX] The ParseMode option is now set explicitly in the Telegram integration. If we don't HTML tags had not been parsed by default. https://github.com/prometheus/alertmanager/pull/4027
- [BUGFIX] Fix a memory leak that was caused by updates silences continuously. https://github.com/prometheus/alertmanager/pull/3930
- [BUGFIX] Fix hiding secret URLs when the URL is incorrect. https://github.com/prometheus/alertmanager/pull/3887
- [BUGFIX] Fix a race condition in the alerts - it was more of a hypothetical race condition that could have occurred in the alert reception pipeline. https://github.com/prometheus/alertmanager/pull/3648
- [BUGFIX] Fix a race condition in the alert delivery pipeline that would cause a firing alert that was delivered earlier to be deleted from the aggregation group when instead it should have been delivered again. https://github.com/prometheus/alertmanager/pull/3826
- [BUGFIX] Fix version in APIv1 deprecation notice. https://github.com/prometheus/alertmanager/pull/3815
- [BUGFIX] Fix crash errors when using url_file in the Webhook integration. https://github.com/prometheus/alertmanager/pull/3800
- [BUGFIX] fix Route.ID() returns conflicting IDs. https://github.com/prometheus/alertmanager/pull/3803
- [BUGFIX] Fix deadlock on the alerts memory store. https://github.com/prometheus/alertmanager/pull/3715
- [BUGFIX] Fix amtool template render when using the default values. https://github.com/prometheus/alertmanager/pull/3725
- [BUGFIX] Fix webhook_url_file for both the Discord and Microsoft Teams integrations. https://github.com/prometheus/alertmanager/pull/3728 https://github.com/prometheus/alertmanager/pull/3745
- [BUGFIX] Fix wechat api link https://github.com/prometheus/alertmanager/pull/4084
- [BUGFIX] Fix build info metric https://github.com/prometheus/alertmanager/pull/4166
- [BUGFIX] Fix UTF-8 not allowed in Equal field for inhibition rules https://github.com/prometheus/alertmanager/pull/4177